### PR TITLE
Allow project-specific config files to be used with older versions of node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,15 @@ function resolveConfigFile(fileName) {
 }
 
 function existsSync(filename) {
-  try {
-    fs.accessSync(filename);
-    return true;
-  } catch (error) {
-    return false;
+  if (typeof(fs.accessSync) === 'function') { // newer node
+    try {
+      fs.accessSync(filename);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  } else { // older node
+    return fs.existsSync(filename);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,10 @@ function existsSync(filename) {
       fs.accessSync(filename);
       return true;
     } catch (error) {
+      if (typeof(error) !== 'object' || error.code !== 'ENOENT') {
+        handyman.log('Unable to access ' + filename + ':');
+        handyman.log(error.stack);
+      }
       return false;
     }
   } else { // older node


### PR DESCRIPTION
```fs.accessSync(path)``` doesn't exist in, eg., [node 0.10.36](https://nodejs.org/docs/v0.10.36/api/fs.html).