### PR TITLE
Refactor index

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,19 @@ root folder of the project. This pipeline will prioritize your rules over the de
 ## Usage
 ```javascript
 var gulp = require('gulp');
-var validatePipeline = require('pipeline-validate-js')();
+var validatePipeline = require('pipeline-validate-js');
 
 
 gulp.task('default', function() {
   return gulp
     .src(files)
     .pipe(validatePipeline.validateJS());
+});
+
+gulp.task('default', function() {
+  return gulp
+    .src(files)
+    .pipe(validatePipeline.validateJS({ecmaversion: 4}));
 });
 ```
 
@@ -43,7 +49,7 @@ Pipeline options:
 
     + __config.disableJSCS:__ If _true_ doesn't validate the files using `jscsrc`. You might want to disable JSCS if working on a legacy project. Otherwise this option should _false_.
 
-    + __config.linter:__ Sets the desire rules to validate the files. It can be set to `JSHint` or `ESLint`.
+    + __config.parseOptions.ecmaVersion:__ Sets the ecmaScript version to be linted, set to '5' by default.
     
     + __config.reporter:__ passthru reporting configuration options to JSHint
 
@@ -52,7 +58,9 @@ Pipeline options:
   ```javascript
   config = {
     disableJSCS: false,
-    linter: 'JSHint',
+    parseOptions: {
+      ecmaVersion: 5
+    },
     reporter: {
       verbose: true
     }

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 # Overview
 
 Gulp Pipeline that allows you to validate the js files within your project. It defines an object that contains a 
-validateJS() function. Depending on the configuration, the function will use JSHint and JSCS to complete the task, or 
-ESLint.
+validateJS() function. The function will use ESLint to complete the task, with an option to enable JSCS.
+
 
 This pipeline also offers the possibility of using personalized lint rules in other modules. If you'd like to use other 
-rules within your project you can define a `.jshintrc`, `.jscs` or a `.eslintrc` file. These files should be in the 
+rules within your project you can define `.jscs` or a `.eslintrc` file. These files should be in the 
 root folder of the project. This pipeline will prioritize your rules over the default configurations.
 
 **NOTE: as this project is still pre 1.0.0, it is subject to possible backwards incompatible changes as it matures.**
@@ -50,8 +50,6 @@ Pipeline options:
     + __config.disableJSCS:__ If _true_ doesn't validate the files using `jscsrc`. You might want to disable JSCS if working on a legacy project. Otherwise this option should _false_.
 
     + __config.parseOptions.ecmaVersion:__ Sets the ecmaScript version to be linted, set to '5' by default.
-    
-    + __config.reporter:__ passthru reporting configuration options to JSHint
 
 
   Default:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var gulp = require('gulp');
-var validatePipeline = require('./src/index.js')();
+var validatePipeline = require('./src/index.js');
 var config = {
   files: [
     '*.js',
-    'src/*.js',
-    'src/**/*.js'
+    './src/*.js',
+    './src/**/*.js'
   ]
 };
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lazypipe": "1.0.1",
     "lodash": "3.10.1",
     "pipeline-handyman": "0.3.0",
-    "sinon": "^1.17.3",
+    "sinon": "1.17.3",
     "yargs": "3.25.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "keywords": [
     "Gulp",
-    "jshint",
     "jscs",
     "eslint",
     "Keystone",
@@ -46,19 +45,14 @@
     "gulp-if": "1.2.5",
     "gulp-jscs": "2.0.0",
     "gulp-jscs-stylish": "1.1.2",
-    "gulp-jshint": "1.11.2",
     "gulp-load-plugins": "0.10.0",
     "gulp-piece": "1.1.1",
     "gulp-print": "1.2.0",
     "gulp-util": "3.0.6",
-    "jshint-stylish": "2.0.1",
     "lazypipe": "1.0.1",
     "lodash": "3.10.1",
     "pipeline-handyman": "0.3.0",
     "sinon": "1.17.3",
-    "yargs": "3.25.0"
-  },
-  "devDependencies": {
     "chai": "3.2.0",
     "mocha": "2.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lazypipe": "1.0.1",
     "lodash": "3.10.1",
     "pipeline-handyman": "0.3.0",
+    "sinon": "^1.17.3",
     "yargs": "3.25.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ var config = {
   parseOptions: {
     ecmaVersion: 5
   },
-  linter: 'JSHint',
+  linter: 'JSCS',
   reporter: {
     verbose: true
   }
@@ -23,43 +23,48 @@ var esLintConfig = resolveConfigFile('.eslintrc');
 
 module.exports = {
   validateJS : function (options) {
-    if (options) {
-      console.log(options);
-      if(options.contains(parseOptions()){
-        options = {parseOptions: options}
-      })
-      config = handyman.mergeConf(config, options);
-
-      switch (config.parseOptions.ecmaVersion) {
-
-        case 6:
-          handyman.log('No support for Ecmascript 7 as of now');
-          return;
-
-        default:
-          handyman.log('Validating js with JSCS, Options not valid');
+    if(options){
+      var keyArray = Object.keys(options);
+      for(var key in keyArray){
+        if(keyArray[key] === 'ecmaVersion'){
+          config.parseOptions.ecmaVersion = options.ecmaVersion
+        }
       }
-      console.log(config);
     }
-    if(config.ecmaVersion)
+
+    switch(true){
+      case config.parseOptions.ecmaVersion >= 3 && config.parseOptions.ecmaVersion <= 5:
+          handyman.log('ecma 5');
+          break;
+      case config.parseOptions.ecmaVersion === 6:
+          handyman.log('ecma 6');
+          break;
+      case config.parseOptions.ecmaVersion === 7:
+          handyman.log('ecma 7');
+          break;
+      default:
+          handyman.log('default ecma5')
+
+    }
 
     return validateES();
   }
+
 }
 
-function validateJSHint() {
-  handyman.log('Validating js with JSCS');
-  var stream = lazypipe()
-    .pipe(function() {
-      return plugins.if(args.verbose, plugins.print());
-    })
-    .pipe(jsValidationCombiner)
-    .pipe(function() {
-      return plugins.if(!config.disableJSCS, plugins.jscsStylish.combineWithHintResults());
-    })
-
-  return stream();
-}
+//function validateJSHint() {
+//  handyman.log('Validating js with JSCS');
+//  var stream = lazypipe()
+//    .pipe(function() {
+//      return plugins.if(args.verbose, plugins.print());
+//    })
+//    .pipe(jsValidationCombiner)
+//    .pipe(function() {
+//      return plugins.if(!config.disableJSCS, plugins.jscsStylish.combineWithHintResults());
+//    })
+//
+//  return stream();
+//}
 
 function jsValidationCombiner() {
 
@@ -97,8 +102,6 @@ function existsSync(filename) {
 }
 
 function validateES() {
-
-  console.log('VALIDATE ES HAS BEEN CALLED')
   handyman.log('Validating js with ESlint');
   var stream = lazypipe()
     .pipe(function() {
@@ -114,3 +117,4 @@ function validateES() {
 
   return stream();
 }
+

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,7 @@ var handyman = require('pipeline-handyman');
 var path = require('path');
 var lazypipe = require('lazypipe');
 
-
-//change to pipelineConfig
-var config = {
+var pipelineConfig = {
   disableJSCS: false,
   parseOptions: {
     ecmaVersion: 5
@@ -18,45 +16,42 @@ var config = {
     verbose: true
   }
 };
-var jsHintConfig = resolveConfigFile('.jshintrc');
 var jscsConfig = resolveConfigFile('.jscsrc');
 var esLintConfig = resolveConfigFile('.eslintrc');
 
 module.exports = {
   validateJS : function (options) {
-    if(options){
+    if (options) {
       var keyArray = Object.keys(options);
 
       if (typeof options !== 'object') {
         handyman.log('Validading js with ESlint ecmaScript5, ** Options not valid **');
       }
 
-      for(var key in keyArray){
-        if(keyArray[key] === 'ecmaVersion'){
-          config.parseOptions.ecmaVersion = options.ecmaVersion
+      for (var key in keyArray) {
+        if (keyArray[key] === 'ecmaVersion') {
+          pipelineConfig.parseOptions.ecmaVersion = options.ecmaVersion
         }
       }
     }
 
-    switch(true){
+    switch (true) {
 
-      case config.parseOptions.ecmaVersion >= 3 && config.parseOptions.ecmaVersion <= 5:
-          handyman.log('Validating js version ' + config.parseOptions.ecmaVersion + ' with ESlint');
+      case pipelineConfig.parseOptions.ecmaVersion >= 3 && pipelineConfig.parseOptions.ecmaVersion <= 5:
+          handyman.log('Validating js version ' + pipelineConfig.parseOptions.ecmaVersion + ' with ESlint');
           break;
       default:
-          handyman.log('Validading js with ESlint ecmaScript5, ** ecmaVersion ' + config.parseOptions.ecmaVersion + ' is not supported! **')
+          handyman.log('Validading js with ESlint ecmaScript5, ** ecmaVersion ' + pipelineConfig.parseOptions.ecmaVersion + ' is not supported! **')
 
     }
 
     return validateES();
   }
-
 }
 
 function jsValidationCombiner() {
-
   return plugins.piece(
-    plugins.if(!config.disableJSCS, plugins.jscs(jscsConfig))
+    plugins.if(!pipelineConfig.disableJSCS, plugins.jscs(jscsConfig))
   );
 }
 
@@ -95,7 +90,7 @@ function validateES() {
     })
     .pipe(jsValidationCombiner)
     .pipe(function() {
-      return plugins.if(!config.disableJSCS, plugins.jscsStylish.combineWithHintResults());
+      return plugins.if(!pipelineConfig.disableJSCS, plugins.jscsStylish.combineWithHintResults());
     })
     .pipe(plugins.eslint, esLintConfig)
     .pipe(plugins.eslint.format)

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,13 @@ var handyman = require('pipeline-handyman');
 var path = require('path');
 var lazypipe = require('lazypipe');
 
+
+//change to pipelineConfig
 var config = {
   disableJSCS: false,
   parseOptions: {
     ecmaVersion: 5
   },
-  linter: 'JSCS',
   reporter: {
     verbose: true
   }
@@ -25,6 +26,11 @@ module.exports = {
   validateJS : function (options) {
     if(options){
       var keyArray = Object.keys(options);
+
+      if (typeof options !== 'object') {
+        handyman.log('Validading js with ESlint ecmaScript5, ** Options not valid **');
+      }
+
       for(var key in keyArray){
         if(keyArray[key] === 'ecmaVersion'){
           config.parseOptions.ecmaVersion = options.ecmaVersion
@@ -33,17 +39,12 @@ module.exports = {
     }
 
     switch(true){
+
       case config.parseOptions.ecmaVersion >= 3 && config.parseOptions.ecmaVersion <= 5:
-          handyman.log('ecma 5');
-          break;
-      case config.parseOptions.ecmaVersion === 6:
-          handyman.log('ecma 6');
-          break;
-      case config.parseOptions.ecmaVersion === 7:
-          handyman.log('ecma 7');
+          handyman.log('Validating js version ' + config.parseOptions.ecmaVersion + ' with ESlint');
           break;
       default:
-          handyman.log('default ecma5')
+          handyman.log('Validading js with ESlint ecmaScript5, ** ecmaVersion ' + config.parseOptions.ecmaVersion + ' is not supported! **')
 
     }
 
@@ -51,20 +52,6 @@ module.exports = {
   }
 
 }
-
-//function validateJSHint() {
-//  handyman.log('Validating js with JSCS');
-//  var stream = lazypipe()
-//    .pipe(function() {
-//      return plugins.if(args.verbose, plugins.print());
-//    })
-//    .pipe(jsValidationCombiner)
-//    .pipe(function() {
-//      return plugins.if(!config.disableJSCS, plugins.jscsStylish.combineWithHintResults());
-//    })
-//
-//  return stream();
-//}
 
 function jsValidationCombiner() {
 
@@ -102,7 +89,6 @@ function existsSync(filename) {
 }
 
 function validateES() {
-  handyman.log('Validating js with ESlint');
   var stream = lazypipe()
     .pipe(function() {
       return plugins.if(args.verbose, plugins.print());

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -19,31 +19,29 @@ describe('pipeline-validateJS', function(){
       (typeof stream).should.equal('object');
     });
     describe('validateJS log outputs', function(){
-      var sandbox;
+      var sandbox, spy;
       beforeEach(function() {
         sandbox = sinon.sandbox.create();
+        spy = sandbox.spy(handyman, 'log');
       });
 
       afterEach(function(){
         sandbox.restore();
       });
 
-      it("should test log", function() {
-        var spy1 = sandbox.spy(handyman, 'log');
+      it("should test validateJS() with no options", function() {
         validatePipeline.validateJS();
-        (spy1.args[0][0]).should.equal('Validating js with JSHInt and JSCS');
+        (spy.args[0][0]).should.equal('Validating js with JSHInt and JSCS');
       });
 
-      it("should test log", function() {
-        var spy1 = sandbox.spy(handyman, 'log');
+      it("should test validateJS() with invalid options", function() {
         validatePipeline.validateJS(234);
-        (spy1.args[0][0]).should.equal('Validating js with JSHInt and JSCS, Options not valid');
+        (spy.args[0][0]).should.equal('Validating js with JSHInt and JSCS, Options not valid');
       });
 
-      it("should test log", function() {
-        var spy1 = sandbox.spy(handyman, 'log');
+      it("should test validateJS() with linter options", function() {
         validatePipeline.validateJS({linter: 'ESLint'});
-        (spy1.args[0][0]).should.equal('Validating js with ESlint');
+        (spy.args[0][0]).should.equal('Validating js with ESlint');
       });
     })
   });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -9,26 +9,21 @@ describe('pipeline-validateJS', function(){
     (typeof validatePipeline).should.equal('object');
     console.log(validatePipeline)
   });
+
   it('should contain a validateJS method', function(){
     (validatePipeline.validateJS).should.exist;
     (typeof validatePipeline.validateJS).should.equal('function');
   });
 
-
-
-
-
-
   describe('validateJS method', function (){
-    console.log('check')
-    var stream = validatePipeline.validateJS({ ecmaVersion : 10 });
+
     it('should return an object', function(){
+      var stream = validatePipeline.validateJS();
       (typeof stream).should.equal('object');
     });
 
-
     describe('validateJS log outputs', function(){
-      var sandbox, spy;
+      var sandbox, spy, stream;
       beforeEach(function() {
         sandbox = sinon.sandbox.create();
         spy = sandbox.spy(handyman, 'log');
@@ -40,17 +35,22 @@ describe('pipeline-validateJS', function(){
 
       it("should test validateJS() with no options", function() {
         validatePipeline.validateJS();
-        (spy.args[0][0]).should.equal('Validating js with JSCS');
+        (spy.args[0][0]).should.equal('Validating js version 5 with ESlint');
       });
 
       it("should test validateJS() with invalid options", function() {
         validatePipeline.validateJS(234);
-        (spy.args[0][0]).should.equal('Validating js with JSCS, Options not valid');
+        (spy.args[0][0]).should.equal('Validading js with ESlint ecmaScript5, ** Options not valid **');
       });
 
-      it("should test validateJS() with linter options", function() {
-        validatePipeline.validateJS({linter: 'ESLint'});
-        (spy.args[0][0]).should.equal('Validating js with ESlint');
+      it("should test validateJS() with ecmaVersion options", function() {
+        validatePipeline.validateJS({ecmaVersion: 5});
+        (spy.args[0][0]).should.equal('Validating js version 5 with ESlint');
+      });
+
+      it("should test validateJS() with not supported ecmaVersion options", function() {
+        validatePipeline.validateJS({ecmaVersion: 7});
+        (spy.args[0][0]).should.equal('Validading js with ESlint ecmaScript5, ** ecmaVersion 7 is not supported! **');
       });
     })
   });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,42 +7,54 @@ var validatePipeline =  require('../src/index.js');
 describe('pipeline-validateJS', function(){
   it('should return a object', function () {
     (typeof validatePipeline).should.equal('object');
+    console.log(validatePipeline)
   });
   it('should contain a validateJS method', function(){
     (validatePipeline.validateJS).should.exist;
     (typeof validatePipeline.validateJS).should.equal('function');
   });
+
+
+
+
+
+
   describe('validateJS method', function (){
-    var stream = validatePipeline.validateJS();
+    console.log('check')
+    var stream = validatePipeline.validateJS({ecmaVersion: 6});
+    //it('should return an object', function(){
+    //  (typeof stream).should.equal('object');
+    //});
 
-    it('should return an object', function(){
-      (typeof stream).should.equal('object');
-    });
-    describe('validateJS log outputs', function(){
-      var sandbox, spy;
-      beforeEach(function() {
-        sandbox = sinon.sandbox.create();
-        spy = sandbox.spy(handyman, 'log');
-      });
 
-      afterEach(function(){
-        sandbox.restore();
-      });
 
-      it("should test validateJS() with no options", function() {
-        validatePipeline.validateJS();
-        (spy.args[0][0]).should.equal('Validating js with JSHInt and JSCS');
-      });
 
-      it("should test validateJS() with invalid options", function() {
-        validatePipeline.validateJS(234);
-        (spy.args[0][0]).should.equal('Validating js with JSHInt and JSCS, Options not valid');
-      });
 
-      it("should test validateJS() with linter options", function() {
-        validatePipeline.validateJS({linter: 'ESLint'});
-        (spy.args[0][0]).should.equal('Validating js with ESlint');
-      });
-    })
+    //describe('validateJS log outputs', function(){
+    //  var sandbox, spy;
+    //  beforeEach(function() {
+    //    sandbox = sinon.sandbox.create();
+    //    spy = sandbox.spy(handyman, 'log');
+    //  });
+    //
+    //  afterEach(function(){
+    //    sandbox.restore();
+    //  });
+    //
+    //  it("should test validateJS() with no options", function() {
+    //    validatePipeline.validateJS();
+    //    (spy.args[0][0]).should.equal('Validating js with JSCS');
+    //  });
+      //
+      //it("should test validateJS() with invalid options", function() {
+      //  validatePipeline.validateJS(234);
+      //  (spy.args[0][0]).should.equal('Validating js with JSCS, Options not valid');
+      //});
+      //
+      //it("should test validateJS() with linter options", function() {
+      //  validatePipeline.validateJS({linter: 'ESLint'});
+      //  (spy.args[0][0]).should.equal('Validating js with ESlint');
+      //});
+    //})
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,31 +1,50 @@
 'use strict';
+var should = require('chai').should();
+var sinon = require('sinon');
+var handyman = require('pipeline-handyman');
+var validatePipeline =  require('../src/index.js');
 
-// TODO Validate stream input and stream output.
+describe('pipeline-validateJS', function(){
+  it('should return a object', function () {
+    (typeof validatePipeline).should.equal('object');
+  });
+  it('should contain a validateJS method', function(){
+    (validatePipeline.validateJS).should.exist;
+    (typeof validatePipeline.validateJS).should.equal('function');
+  });
+  describe('validateJS method', function (){
+    var stream = validatePipeline.validateJS();
 
-// var validatePipeline = require('../src/index.js')();
-// var should = require('chai').should();
-// var gulp = require('gulp');
+    it('should return an object', function(){
+      (typeof stream).should.equal('object');
+    });
+    describe('validateJS log outputs', function(){
+      var sandbox;
+      beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+      });
 
-describe('pipeline-validate-js', function() {
-//   it('should emit error on streamed file', function (done) {
-//     gulp
-//       .src('../src/resources.js')
-//       .pipe(validatePipeline.validateJS())
-//       .on('data', function (err) {
-//         err.message.should.eql('Streaming not supported');
-//         done();
-//       });
-//     done();
-//   });
+      afterEach(function(){
+        sandbox.restore();
+      });
 
-  // it('should emit error on streamed file', function (done) {
-  //   var stream = validatePipeline.validateJS();
-  //   stream.on('data', function() {
-  //     done();
-  //   });
-  //   stream.on('end', function() {
-  //       done();
-  //   });
-  //   stream.end(done);
-  // });
+      it("should test log", function() {
+        var spy1 = sandbox.spy(handyman, 'log');
+        validatePipeline.validateJS();
+        (spy1.args[0][0]).should.equal('Validating js with JSHInt and JSCS');
+      });
+
+      it("should test log", function() {
+        var spy1 = sandbox.spy(handyman, 'log');
+        validatePipeline.validateJS(234);
+        (spy1.args[0][0]).should.equal('Validating js with JSHInt and JSCS, Options not valid');
+      });
+
+      it("should test log", function() {
+        var spy1 = sandbox.spy(handyman, 'log');
+        validatePipeline.validateJS({linter: 'ESLint'});
+        (spy1.args[0][0]).should.equal('Validating js with ESlint');
+      });
+    })
+  });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -21,40 +21,37 @@ describe('pipeline-validateJS', function(){
 
   describe('validateJS method', function (){
     console.log('check')
-    var stream = validatePipeline.validateJS({ecmaVersion: 6});
-    //it('should return an object', function(){
-    //  (typeof stream).should.equal('object');
-    //});
+    var stream = validatePipeline.validateJS({ ecmaVersion : 10 });
+    it('should return an object', function(){
+      (typeof stream).should.equal('object');
+    });
 
 
+    describe('validateJS log outputs', function(){
+      var sandbox, spy;
+      beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+        spy = sandbox.spy(handyman, 'log');
+      });
 
+      afterEach(function(){
+        sandbox.restore();
+      });
 
+      it("should test validateJS() with no options", function() {
+        validatePipeline.validateJS();
+        (spy.args[0][0]).should.equal('Validating js with JSCS');
+      });
 
-    //describe('validateJS log outputs', function(){
-    //  var sandbox, spy;
-    //  beforeEach(function() {
-    //    sandbox = sinon.sandbox.create();
-    //    spy = sandbox.spy(handyman, 'log');
-    //  });
-    //
-    //  afterEach(function(){
-    //    sandbox.restore();
-    //  });
-    //
-    //  it("should test validateJS() with no options", function() {
-    //    validatePipeline.validateJS();
-    //    (spy.args[0][0]).should.equal('Validating js with JSCS');
-    //  });
-      //
-      //it("should test validateJS() with invalid options", function() {
-      //  validatePipeline.validateJS(234);
-      //  (spy.args[0][0]).should.equal('Validating js with JSCS, Options not valid');
-      //});
-      //
-      //it("should test validateJS() with linter options", function() {
-      //  validatePipeline.validateJS({linter: 'ESLint'});
-      //  (spy.args[0][0]).should.equal('Validating js with ESlint');
-      //});
-    //})
+      it("should test validateJS() with invalid options", function() {
+        validatePipeline.validateJS(234);
+        (spy.args[0][0]).should.equal('Validating js with JSCS, Options not valid');
+      });
+
+      it("should test validateJS() with linter options", function() {
+        validatePipeline.validateJS({linter: 'ESLint'});
+        (spy.args[0][0]).should.equal('Validating js with ESlint');
+      });
+    })
   });
 });


### PR DESCRIPTION
validateES and validateJSHint  functions had to be setup different to meet the criteria for the new way to invoke the validatePipeline.validateJS('') function.

edit: this resolves issue #40 and #19 

**NOTE: this understands it is breaking backwards compatibility.  The developers will make this the official 1.0.0 release of the pipeline as a result**