### PR TITLE
Fix 77: Update ESLint to version 3.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,13 +33,10 @@ gulp.task('test', ['lint'], function () {
   .src(validateConfig.test.files)
   .pipe(testPipeline.test({
     plugins: {
-      mocha: {
-        reporter: 'spec'
-      },
       istanbul: {
         includeUntested: true,
         writeReports: {
-          reporters: ['html', 'text-summary', 'cobertura']
+          reporters: ['html', 'text-summary', 'cobertura', 'lcov']
         },
         thresholds: {
           global: 75

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('test', ['lint'], function () {
       istanbul: {
         includeUntested: true,
         writeReports: {
-          reporters: ['html', 'text-summary']
+          reporters: ['html', 'text-summary', 'cobertura']
         },
         thresholds: {
           global: 75

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,19 +31,7 @@ gulp.task('lint', function () {
 gulp.task('test', ['lint'], function () {
   return gulp
   .src(validateConfig.test.files)
-  .pipe(testPipeline.test({
-    plugins: {
-      istanbul: {
-        includeUntested: true,
-        writeReports: {
-          reporters: ['html', 'text-summary', 'cobertura', 'lcov']
-        },
-        thresholds: {
-          global: 75
-        }
-      }
-    }
-  }));
+  .pipe(testPipeline.test());
 });
 
 gulp.task('build', ['test']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,14 +22,31 @@ var validateConfig = {
   }
 };
 
-gulp.task('lint', function() {
+gulp.task('lint', function () {
   return gulp
-    .src(validateConfig.linter.files)
-    .pipe(validatePipeline.validateJS());
+  .src(validateConfig.linter.files)
+  .pipe(validatePipeline.validateJS());
 });
 
-gulp.task('build', ['lint'], function() {
+gulp.task('test', ['lint'], function () {
   return gulp
-    .src(validateConfig.test.files)
-    .pipe(testPipeline.test());
+  .src(validateConfig.test.files)
+  .pipe(testPipeline.test({
+    plugins: {
+      mocha: {
+        reporter: 'spec'
+      },
+      istanbul: {
+        includeUntested: true,
+        writeReports: {
+          reporters: ['html', 'text-summary']
+        },
+        thresholds: {
+          global: 75
+        }
+      }
+    }
+  }));
 });
+
+gulp.task('build', ['test']);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline-validate-js",
   "version": "1.0.0-rc4",
-  "description": "Gulp pipeline to validate js files using JSHint and JSCS or ESLint",
+  "description": "Gulp pipeline to validate js files using ESLint",
   "author": "Juan P. Osorio <jposorio@kenzan.com> (https://github.com/jpoo90)",
   "contributors": [
     {
@@ -11,6 +11,10 @@
     {
       "name": "Chris Sharon",
       "email": "csharon@kenzan.com"
+    },
+    {
+      "name": "Paul Barry",
+      "email": "pbarry@kenzan.com"
     }
   ],
   "scripts": {
@@ -40,7 +44,7 @@
   "analyze": true,
   "license": "Apache 2",
   "dependencies": {
-    "gulp-eslint": "2.0.0",
+    "gulp-eslint": "3.0.1",
     "lazypipe": "1.0.1",
     "lodash": "3.10.1",
     "pipeline-handyman": "1.0.0"


### PR DESCRIPTION
EDIT:
The `gulp-eslint` version is needed to update to ESLint v.3. I also included a dedicated gulp task for testing, as well as updated the testing pipeline version. 