### PR TITLE
Fix #84: Add options to customize format and fail condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ gulp.task('lint', function() {
 });
 ```
 
+### Failing on Errors
+By default, this pipeline will exit on a validation error. To prevent this exit on failure, provide the following option to the pipeline.
+
+```javascript
+var lintConfig = {
+  failOnError: false
+}
+
+gulp.task('lint', function() {
+  return gulp
+    .src('src/**/*.js')
+    .pipe(validatePipeline.validateJS(lintConfig));
+});
+```
+
+As with the custom formatting option, this option *will not* conflict with the ESLint default configuration options.
+
 ## Results
 
 This pipeline returns an object. This object receives a stream with the files to validate. You can call the _validateJS_

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 | pipeline-validate-js| Pipeline to validate JavaScript files using ESLint | 1.0.0-rc4 |
 
 # Overview
-This is a [Gulp][] pipeline that allows a team to validate the JS files within their project for syntax and style. As 
-part of the [Keystone][] project for [Kenzan][], this pipeline is opinionated to promote best practices as favored by 
-the organization. It defines a module that contains a `validateJS` method that will use [ESLint][] to complete the 
+This is a [Gulp][] pipeline that allows a team to validate the JS files within their project for syntax and style. As
+part of the [Keystone][] project for [Kenzan][], this pipeline is opinionated to promote best practices as favored by
+the organization. It defines a module that contains a `validateJS` method that will use [ESLint][] to complete the
 task.
 
 A fixture has been provided in `test/fixtures/` of Twitter [Bootstrap][]'s [source][], linted according to the rules.
-As changes are presented to the default ruleset, the rules will be reflected in this file as well, for easy 
+As changes are presented to the default ruleset, the rules will be reflected in this file as well, for easy
 visualiztion of rule set changes.
 
 [Gulp]: http://gulpjs.com/
@@ -24,7 +24,7 @@ visualiztion of rule set changes.
 [Bootstrap]: http://getbootstrap.com/
 [source]: https://github.com/twbs/bootstrap/blob/v3.3.6/dist/js/bootstrap.js
 
-**NOTE: this project is now in a 1.0.0 release candidate stage.  1.0.0-rc tags will be published to NPM to allow 
+**NOTE: this project is now in a 1.0.0 release candidate stage.  1.0.0-rc tags will be published to NPM to allow
 developers the chance to review and provide feedback.**
 
 ## Install
@@ -68,6 +68,8 @@ gulp.task('default', function() {
 
 ## Options
 
+**Note:** If options are invalid it will throw a reference error.
+
 Pipeline options:
 * _config_ -> Object that contains the configuration.  It offers a 1:1 mapping with the format of an `eslintrc` file
 
@@ -83,7 +85,28 @@ Pipeline options:
   }
   ```
 
-If options are invalid it will throw a reference error.
+### Custom Formatter
+ESLint provides the ability to [output the results in a variety of formats](http://eslint.org/docs/user-guide/command-line-interface#f---format), thus, a custom formatter can be provided via the config object.
+
+ESLint provided formatters: https://github.com/eslint/eslint/tree/master/lib/formatters
+
+The custom formatter options *will not* conflict with the default ESLint options provided, so you can provide just a formatter while retaining the default ESLint option values.
+
+```javascript
+var lintConfig = {
+  formatter: 'name-of-eslint-formatter'
+  // OR
+  // formatter: function (arrayOfResults) {
+    // output something here
+  // }
+}
+
+gulp.task('lint', function() {
+  return gulp
+    .src('src/**/*.js')
+    .pipe(validatePipeline.validateJS(lintConfig));
+});
+```
 
 ## Results
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "gulp-eslint": "3.0.1",
     "lazypipe": "1.0.1",
     "lodash": "4.17.4",
-    "pipeline-handyman": "1.0.0"
+    "pipeline-handyman": "1.0.0",
+    "through2": "2.0.3"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ var handyman = require('pipeline-handyman');
 var lazypipe = require('lazypipe');
 var path = require('path');
 var _ = require('lodash');
+var through2 = require('through2');
 
 var ESLINT_DEFAULT_CONFIG_PATH = 'node_modules/pipeline-validate-js/.eslintrc';
 var ESLINT_ROOT_CONFIG_PATH = '.eslintrc';
@@ -76,7 +77,15 @@ function pipelineFactory (config) {
     stream = lazypipe()
       .pipe(eslint, config)
       .pipe(eslint.format, config.formatter)
-      .pipe(eslint.failOnError);
+      .pipe(function () {
+        var failOnError = config.hasOwnProperty('failOnError') && typeof config.failOnError !== 'undefined' ? config.failOnError : true;
+
+        if (failOnError) {
+          return eslint.failOnError();
+        } else {
+          return through2.obj();
+        }
+      });
 
     return stream();
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ module.exports = {
   }
 };
 
-function checkLocalLintFile(options) {
+function checkLocalLintFile (options) {
   var config = {};
   var defaultPath = path.join(process.cwd(), ESLINT_DEFAULT_CONFIG_PATH);
   var rootPath = path.join(process.cwd(), ESLINT_ROOT_CONFIG_PATH);
@@ -69,14 +69,14 @@ function checkLocalLintFile(options) {
   return config;
 }
 
-function pipelineFactory(config) {
+function pipelineFactory (config) {
   var stream;
 
   if (typeof config === 'object') {
     stream = lazypipe()
-        .pipe(eslint.format)
-        .pipe(eslint, config)
-        .pipe(eslint.failOnError);
+      .pipe(eslint, config)
+      .pipe(eslint.format, config.formatter)
+      .pipe(eslint.failOnError);
 
     return stream();
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -147,6 +147,28 @@ describe('pipeline-validateJS', function () {
         spy.should.have.been.calledWith('Parsing Options');
       });
 
+      describe('ValidateJS Pipeline with custom formatter', function () {
+
+        it('should utilize eslint.format when a custom formatter name is provided', function () {
+          var spy = esLint.format;
+
+          pipeline({ formatter: 'checkstyle' });
+
+          expect(spy).to.have.been.calledWith('checkstyle');
+        });
+
+        it('should utilize eslint.format when a custom formatter function is provided', function () {
+          var spy = esLint.format;
+          var dummyFunc = function () {
+          };
+
+          pipeline({ formatter: dummyFunc });
+
+          expect(spy).to.have.been.calledWith(dummyFunc);
+        });
+
+      });
+
     });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -169,6 +169,22 @@ describe('pipeline-validateJS', function () {
 
       });
 
+      describe('ValidateJS Pipeline without failing on an error', function () {
+
+        it('should not utilize eslint.failOnError when the failOnError options is "false"', function () {
+          var spy = esLint.failOnError;
+
+          spy.reset();
+
+          pipeline({
+            failOnError: false
+          });
+
+          expect(spy).to.have.not.been.called();
+        });
+
+      });
+
     });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -11,6 +11,8 @@ var rimraf = require('rimraf');
 var validatePipeline = require('../src/index.js');
 var expect = chai.expect;
 
+var esLint = require('gulp-eslint');
+
 chai.should();
 chai.use(sinonChai);
 chai.use(dirtyChai);
@@ -39,95 +41,101 @@ describe('pipeline-validateJS', function () {
     rimraf.sync(mockLintConfigPath.replace('.eslintrc', ''));
   });
 
-  it('should expose a validateJS method', function () {
-    expect(validatePipeline.validateJS).to.exist();
-  });
-
-  it('should return a stream', function () {
-    expect(isStream(validatePipeline.validateJS())).to.be.true();
-  });
-
-  it('should return a object', function () {
-    (typeof validatePipeline).should.equal('object');
-  });
-
-  it('should contain a validateJS method', function() {
-    pipeline = validatePipeline.validateJS;
-    pipeline.should.exist;
-    (typeof pipeline).should.equal('function');
-  });
-
   describe('validateJS method', function () {
-    var stream;
 
-    beforeEach(function() {
-      stream = function() {return pipeline();};
+    it('should expose a validateJS method', function () {
+      expect(validatePipeline.validateJS).to.exist();
+      expect(validatePipeline.validateJS).to.be.a('function');
     });
 
-    it('should return a stream', function() {
-      isStream(stream()).should.equal(true);
+    it('should return a stream object', function () {
+      expect(validatePipeline.validateJS()).to.be.an('object');
+      expect(isStream(validatePipeline.validateJS())).to.be.true();
     });
 
-    describe('validateJS pipeline with no options', function() {
+    describe('validateJS pipeline with no options', function () {
       var sandbox = {};
       var spy = {};
 
-      beforeEach(function() {
+      beforeEach(function () {
         sandbox = sinon.sandbox.create();
         spy = sandbox.spy(handyman, 'log');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         sandbox.restore();
       });
 
-      it('should test validateJS() with no options', function() {
+      it('should test validateJS() with no options', function () {
         pipeline();
         spy.should.have.been.calledWith('Validating js with ESlint');
       });
+
+      it('should utilize eslint.format when no options are provided', function () {
+        var spy = sinon.spy(esLint, 'format');
+
+        pipeline();
+
+        expect(spy).to.have.been.called();
+      });
+
+      it('should utilize eslint.failOnError when no options are provided', function () {
+        var spy = sinon.spy(esLint, 'failOnError');
+
+        pipeline();
+
+        expect(spy).to.have.been.called();
+      });
+
     });
 
-    describe('ValidateJS Pipeline with options', function() {
+    describe('ValidateJS Pipeline with options', function () {
       var sandbox = {};
       var spy = {};
       var fn;
 
-      beforeEach(function() {
+      beforeEach(function () {
         sandbox = sinon.sandbox.create();
         spy = sandbox.spy(handyman, 'log');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         sandbox.restore();
       });
 
-      it('should test validateJS() with invalid options, number', function() {
-        fn = function() {pipeline(234);};
+      it('should test validateJS() with invalid options, number', function () {
+        fn = function () {
+          pipeline(234);
+        };
 
         fn.should.throw();
         spy.should.have.been.calledWith('** Options not valid **');
       });
 
-      it('should test validateJS() with invalid options, array', function() {
-        fn = function() {pipeline(['semi', 1]);};
+      it('should test validateJS() with invalid options, array', function () {
+        fn = function () {
+          pipeline(['semi', 1]);
+        };
 
         fn.should.throw();
         spy.should.have.been.calledWith('** Options not valid **');
       });
 
-      it('should test validateJS() with an invalid file path as an  option', function() {
-        fn = function() { pipeline('.eslintrc1'); };
+      it('should test validateJS() with an invalid file path as an  option', function () {
+        fn = function () {
+          pipeline('.eslintrc1');
+        };
 
         fn.should.throw();
       });
 
-      it('should test validateJS() with valid url as options', function() {
+      it('should test validateJS() with valid url as options', function () {
         pipeline('./test/fixtures/.eslintrc3');
 
         spy.should.have.been.calledWith('Linting using custom file');
       });
 
-      it('should test validateJS() with valid url as options', function() {
+      it('should test validateJS() with valid url as options', function () {
         pipeline('./test/fixtures/.eslintrc3');
 
         spy.should.have.been.calledWith(sinon.match(/^Linting using.*eslintrc3$/));


### PR DESCRIPTION
**Associated Issue** 
#84 

**Changes Made**
- Implemented 2 new configuration options
  - `formatter` allows the output results to be customized
  - `failOnError` allows for the option to avoid exiting the pipeline when a failure occurs
- Update README with details
- Reorganized and added additional tests to ensure proper functionality.

**Reviewers**
@obuckley-kenzan 
@bsawyer 
@maksimlikharev