### PR TITLE
Fix #93: Remove empty globals property

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,8 +4,6 @@
         "node": true
     },
 
-    "globals": {},
-
     "plugins": [],
     "rules": {
         "comma-dangle": [2,"never"],


### PR DESCRIPTION
**Associated Ticket**
#92 

**Changes Made**
- Remove empty "globals" property from `.eslintrc`