### PR TITLE
Fix #42: Add means of formatting env values for gulp-eslint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,10 @@ function checkLocalLintFile (options) {
       // no op.
     }
 
+    config.envs = Object.keys(config.env || {}).map(function (name) {
+      return config.env[name] ? name : '';
+    });
+
   }
 
   return config;

--- a/src/index.js
+++ b/src/index.js
@@ -65,11 +65,11 @@ function checkLocalLintFile (options) {
       // no op.
     }
 
-    config.envs = Object.keys(config.env || {}).map(function (name) {
-      return config.env[name] ? name : '';
-    });
-
   }
+
+  config.envs = Object.keys(config.env || {}).map(function (name) {
+    return config.env[name] ? name : '';
+  });
 
   return config;
 }


### PR DESCRIPTION
**Associated Issue:**
#42 

**Changes made:**
- Add a simple mapping method to ensure that the config is formatted properly for `gulp-eslint`

